### PR TITLE
Use Atomic Bool Instead Mutex

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"sync"
 	"time"
 
 	badger "github.com/dgraph-io/badger/v2"
@@ -22,9 +21,8 @@ var ErrClosed = errors.New("datastore closed")
 type Datastore struct {
 	DB *badger.DB
 
-	closed    *abool.AtomicBool
-	closeOnce sync.Once
-	closing   chan struct{}
+	closed  *abool.AtomicBool
+	closing chan struct{}
 
 	gcDiscardRatio float64
 	gcSleep        time.Duration

--- a/datastore.go
+++ b/datastore.go
@@ -275,14 +275,15 @@ func (d *Datastore) GetSize(key ds.Key) (size int, err error) {
 
 // Delete remove the key+value from our datastore
 func (d *Datastore) Delete(key ds.Key) error {
+	if d.closed.IsSet() {
+		return ErrClosed
+	}
 	txn := d.newImplicitTransaction(false)
 	defer txn.discard()
-
 	err := txn.delete(key)
 	if err != nil {
 		return err
 	}
-
 	return txn.commit()
 }
 

--- a/datastore.go
+++ b/datastore.go
@@ -289,6 +289,9 @@ func (d *Datastore) Delete(key ds.Key) error {
 
 // Query is used to perform a search of the keys and values in our datastore
 func (d *Datastore) Query(q dsq.Query) (dsq.Results, error) {
+	if d.closed.IsSet() {
+		return nil, ErrClosed
+	}
 	txn := d.newImplicitTransaction(true)
 	// We cannot defer txn.Discard() here, as the txn must remain active while the iterator is open.
 	// https://github.com/dgraph-io/badger/commit/b1ad1e93e483bbfef123793ceedc9a7e34b09f79

--- a/datastore.go
+++ b/datastore.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -633,9 +632,6 @@ func (t *txn) query(q dsq.Query) (dsq.Results, error) {
 	for {
 		select {
 		case <-done:
-			for len(resultChan) > 0 {
-				time.Sleep(time.Microsecond * time.Duration(rand.Intn(len(resultChan))))
-			}
 			goto FINISHED
 		case result := <-resultChan:
 			if result.Error != nil {

--- a/datastore.go
+++ b/datastore.go
@@ -311,15 +311,10 @@ func (d *Datastore) DiskUsage() (uint64, error) {
 
 // Close is used to close our datastore and cease operations.
 func (d *Datastore) Close() error {
-	d.closeOnce.Do(func() {
-		close(d.closing)
-	})
-	if d.closed.IsSet() {
-		return ErrClosed
-	}
 	if !d.closed.SetToIf(false, true) {
 		return ErrClosed
 	}
+	close(d.closing)
 	return d.DB.Close()
 }
 

--- a/ds_test.go
+++ b/ds_test.go
@@ -305,6 +305,18 @@ func TestBatching(t *testing.T) {
 
 }
 
+func TestPutTTL(t *testing.T) {
+	d, done := newDS(t)
+	defer done()
+	if err := d.PutWithTTL(
+		ds.NewKey("misctest-1"),
+		[]byte(string("hello")),
+		time.Hour,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Tests from basic_tests from go-datastore
 
 func TestBasicPutGet(t *testing.T) {

--- a/ds_test.go
+++ b/ds_test.go
@@ -317,6 +317,55 @@ func TestPutTTL(t *testing.T) {
 	}
 }
 
+func TestClose(t *testing.T) {
+	path, err := ioutil.TempDir(os.TempDir(), "testing_badger_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewDatastore(path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(path)
+	d.Close()
+	if _, err := d.NewTransaction(false); err == nil {
+		t.Fatal("error expected")
+	}
+	if err := d.Put(ds.Key{}, nil); err == nil {
+		t.Fatal("error expected")
+	}
+	if err := d.PutWithTTL(ds.Key{}, nil, 0); err == nil {
+		t.Fatal("error expected")
+	}
+	if err := d.SetTTL(ds.Key{}, 0); err == nil {
+		t.Fatal("error expected")
+	}
+	if _, err := d.GetExpiration(ds.Key{}); err == nil {
+		t.Fatal("error expected")
+	}
+	if _, err := d.Get(ds.Key{}); err == nil {
+		t.Fatal("error expected")
+	}
+	if _, err := d.Has(ds.Key{}); err == nil {
+		t.Fatal("error expected")
+	}
+	if _, err := d.GetSize(ds.Key{}); err == nil {
+		t.Fatal("error expected")
+	}
+	if err := d.Delete(ds.Key{}); err == nil {
+		t.Fatal("error expected")
+	}
+	if _, err := d.Query(dsq.Query{}); err == nil {
+		t.Fatal("error expected")
+	}
+	if _, err := d.DiskUsage(); err == nil {
+		t.Fatal("error expected")
+	}
+	if err := d.Close(); err == nil {
+		t.Fatal("error expected")
+	}
+}
+
 // Tests from basic_tests from go-datastore
 
 func TestBasicPutGet(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/RTradeLtd/go-ds-badger/v2
 require (
 	github.com/dgraph-io/badger/v2 v2.0.1-0.20191128171928-407e5bde06c4
 	github.com/ipfs/go-datastore v0.1.1
+	github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5 h1:hNna6Fi0eP1f2sMBe/rJicDmaHmoXGe1Ta84FPYHLuE=
+github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5/go.mod h1:f1SCnEOt6sc3fOJfPQDRDzHOtSXuTtnz0ImG9kPRDV0=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
Avoid having to make excessive sync unlocks/locks to check a boolean, adds some extra tests. Additionally it gets rid of the `sync.Once` usage, and makes the `badger.DB` field of the `Datastore` struct a private field.